### PR TITLE
Example tasking prototypes for on demand and real-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # vautomator-serverless
 Repository to experiment with serverless framework and automation.
 
-This project uses serverless framework and attempts to create a serverless environment that could be used to automate vulnerability assessment tasks with multiple ingestion points, such as on-demand submission of a host via a REST API, regular scanning of a list of hosts and proactive scanning of hosts appearing in Certificate Transparency logs.
+This project uses serverless framework and attempts to create a serverless environment that could be used to automate vulnerability assessment tasks from multiple ingestion points, such as on-demand submission of a host via a REST API, regular scanning of a known list of hosts, and opportunistically scanning of hosts appearing in Certificate Transparency logs.
 
 This is under development with more features being added as different branches. The current branch supports:
 - Addition of a target to the scan queue for port scan by an API endpoint (`/ondemand/portscan`). Due to the intrusive nature of this endpoint, it is protected by an API key.

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ START RequestId: 6a3bc71b-e369-498c-849c-f522e79ce734 Version: $LATEST
 ```
 - To kick off a port scan on a target on demand, do:
 ```
-$ curl --header "x-api-key: <API-KEY> -X PUT -d '{"target": "www.smh.com.au"}' https://<YOUR-API-ENDPOINT>/dev/ondemand/portscan`
+$ curl --header "x-api-key: <API-KEY> -X POST -d '{"target": "www.smh.com.au"}' https://<YOUR-API-ENDPOINT>/dev/ondemand/portscan`
 {"uuid": "3c74a069-4aac-4b3a-9f0e-29af42874b1b"}
 ```
   - Observe the target added to the scan queue with: `sls logs -f onDemandPortScan`
 
 - To kick off an Observatory scan on a target on demand:
 ```
-curl -X PUT -d '{"target": "www.smh.com.au"}' https://<YOUR-API-ENDPOINT>/dev/ondemand/observatory
+curl -X POST -d '{"target": "www.smh.com.au"}' https://<YOUR-API-ENDPOINT>/dev/ondemand/observatory
 {"uuid": "a542444e-8df3-47b5-a2b8-3e1b0f3c6668"}
 ```
   - Observe the target added to the scan queue with: `sls logs -f onDemandObservatoryScan`

--- a/examples/ondemand_tasker.py
+++ b/examples/ondemand_tasker.py
@@ -1,0 +1,15 @@
+import logging
+import sys
+import datetime
+import json
+
+# This is an example of an on demand scan that an engineer might run should they have
+# interest in getting immediate vulnerability data about a given FQDN.  This would be
+# the interface an engineer could use to kick off a VA.
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+fqdn = input("Provide the FQDN (Fully Qualified Domain Name) you want to scan: ")
+# TODO: add relevant tasking call here to /ondemand/portscan, /ondemand/observatory, etc.
+logger.info("Triggered a vulnerability scan of: {}".format(fqdn))

--- a/examples/realtime_ctlog_tasker.py
+++ b/examples/realtime_ctlog_tasker.py
@@ -1,0 +1,39 @@
+import logging
+import sys
+import datetime
+import certstream
+import json
+
+# This is an example of a long-running service/process which will monitor for
+# CT Logs in real-time and as soon as a certificat_update action is triggered
+# for a domain pattern we care about, we will immediately take action to task
+# those scans via our public REST API endpoints
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def print_callback(message, context):
+    logging.debug("Message -> {}".format(message))
+
+    if message['message_type'] == "certificate_update":
+        all_domains = message['data']['leaf_cert']['all_domains']
+
+        domain_patterns = [
+            ".mozilla.com",
+            ".mozilla.org",
+            ".firefox.com",
+            ".com",  # for testing purposes only, remove before setting live
+        ]
+
+        for fqdn in all_domains:
+            for domain_pattern in domain_patterns:
+                # We want all legit FDQNs, but we can't scan wild-cards
+                if fqdn.endswith(domain_pattern) and ('*' not in fqdn):
+                    # TODO: add relevant tasking call here to /ondemand/portscan, /ondemand/observatory, etc.
+                    logger.info("Triggered a vulnerability scan of: {}".format(fqdn))
+
+
+logging.basicConfig(format='[%(levelname)s:%(name)s] %(asctime)s - %(message)s', level=logging.INFO)
+
+certstream.listen_for_events(print_callback, url='wss://certstream.calidog.io/')

--- a/examples/realtime_ctlog_tasker.py
+++ b/examples/realtime_ctlog_tasker.py
@@ -24,7 +24,6 @@ def print_callback(message, context):
             ".mozilla.com",
             ".mozilla.org",
             ".firefox.com",
-            ".com",  # for testing purposes only, remove before setting live
         ]
 
         for fqdn in all_domains:

--- a/examples/realtime_ctlog_tasker.py
+++ b/examples/realtime_ctlog_tasker.py
@@ -3,11 +3,12 @@ import sys
 import datetime
 import certstream
 import json
+import requests
 
 # This is an example of a long-running service/process which will monitor for
 # CT Logs in real-time and as soon as a certificat_update action is triggered
 # for a domain pattern we care about, we will immediately take action to task
-# those scans via our public REST API endpoints
+# port scans and observatory scans by calling our public REST API endpoints
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -30,8 +31,14 @@ def print_callback(message, context):
             for domain_pattern in domain_patterns:
                 # We want all legit FDQNs, but we can't scan wild-cards
                 if fqdn.endswith(domain_pattern) and ('*' not in fqdn):
-                    # TODO: add relevant tasking call here to /ondemand/portscan, /ondemand/observatory, etc.
-                    logger.info("Triggered a vulnerability scan of: {}".format(fqdn))
+
+                    # TODO: add relevant tasking call here to /ondemand/portscan
+                    logger.info("Sends POST to https://<YOUR-API-ENDPOINT>/dev/ondemand/portscan")
+                    logger.info("Triggered a Port Scan of: {}".format(fqdn))
+
+                    # TODO: add relevant tasking call here to /ondemand/observatoryscan
+                    logger.info("Sends POST to https://<YOUR-API-ENDPOINT>/dev/ondemand/observatory")
+                    logger.info("Triggered an Observatory Scan of: {}".format(fqdn))
 
 
 logging.basicConfig(format='[%(levelname)s:%(name)s] %(asctime)s - %(message)s', level=logging.INFO)

--- a/serverless.yml
+++ b/serverless.yml
@@ -58,7 +58,7 @@ functions:
     events:
       - http:
           path: ondemand/portscan
-          method: PUT
+          method: POST
           cors: true
           private: ${self:custom.cfg.private}
   onDemandObservatoryScan:
@@ -66,7 +66,7 @@ functions:
     events:
       - http:
           path: ondemand/observatory
-          method: PUT
+          method: POST
           cors: true
   cronPortScan:
     handler: handler.addScheduledPortScansToQueue


### PR DESCRIPTION
These are simple scripts that prototype the type of interface we could expect for on demand and ctlog watching tasking types.

The actual logic that triggers scheduled scans can of course live right inside the serverless project (although it doesn't need to be).

I think what these do is sort of echo the intent that the boundary for the server is more about the API front end and  the work it does, rather than the N means by which we can trigger a tasking (examples include ondemand, real-time, and sdcheduled).
