### PR TITLE
Add SSH Observatory Scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ To confirm all scans were performed and results were stored in S3:
 ```
 $ aws s3 ls s3://<your-bucket-name>
 2019-03-12 15:32:00       6906 infosec.mozilla.org.json
-2019-03-12 22:52:00       6906 infosec.mozilla.org_observatory.json
+2019-03-12 22:52:00       6906 infosec.mozilla.org_httpobservatory.json
+2019-03-12 22:52:00       6906 infosec.mozilla.org_sshobservatory.json
 2019-03-12 15:42:00       9209 www.mozilla.org.json
-2019-03-12 22:27:00       9209 www.mozilla.org_observatory.json
+2019-03-12 22:27:00       9209 www.mozilla.org_httpobservatory.json
+2019-03-12 22:27:00       9209 www.mozilla.org_sshobservatory.json
 2019-03-07 16:41:27       5630 www.smh.com.au_tcpscan.json
-2019-03-12 22:49:33       5697 www.smh.com.au_observatory.json
-
+2019-03-12 22:49:33       5697 www.smh.com.au_org_httpobservatory.json
+2019-03-12 22:49:33       5697 www.smh.com.au_org_sshobservatory.json
 ```

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ REPORT RequestId: 2298e8f2-17ac-5e78-8608-bdf388a42dba	Duration: 590.75 ms	Bille
 To confirm all scans were performed and results were stored in S3:
 ```
 $ aws s3 ls s3://<your-bucket-name>
-2019-03-12 15:32:00       6906 infosec.mozilla.org.json
+2019-03-12 15:32:00       6906 infosec.mozilla.org_tcpscan.json
 2019-03-12 22:52:00       6906 infosec.mozilla.org_httpobservatory.json
 2019-03-12 22:52:00       6906 infosec.mozilla.org_sshobservatory.json
-2019-03-12 15:42:00       9209 www.mozilla.org.json
+2019-03-12 15:42:00       9209 www.mozilla.org_tcpscan.json
 2019-03-12 22:27:00       9209 www.mozilla.org_httpobservatory.json
 2019-03-12 22:27:00       9209 www.mozilla.org_sshobservatory.json
 2019-03-07 16:41:27       5630 www.smh.com.au_tcpscan.json

--- a/README.md
+++ b/README.md
@@ -43,12 +43,19 @@ $ curl --header "x-api-key: <API-KEY> -X POST -d '{"target": "www.smh.com.au"}' 
 ```
   - Observe the target added to the scan queue with: `sls logs -f onDemandPortScan`
 
-- To kick off an Observatory scan on a target on demand:
+- To kick off an HTTP Observatory scan on a target on demand:
 ```
-curl -X POST -d '{"target": "www.smh.com.au"}' https://<YOUR-API-ENDPOINT>/dev/ondemand/observatory
+curl -X POST -d '{"target": "www.smh.com.au"}' https://<YOUR-API-ENDPOINT>/dev/ondemand/httpobservatory
 {"uuid": "a542444e-8df3-47b5-a2b8-3e1b0f3c6668"}
 ```
-  - Observe the target added to the scan queue with: `sls logs -f onDemandObservatoryScan`
+  - Observe the target added to the scan queue with: `sls logs -f onDemandHttpObservatoryScan`
+
+- To kick off an SSH Observatory scan on a target on demand:
+```
+curl -X POST -d '{"target": "www.smh.com.au"}' https://<YOUR-API-ENDPOINT>/dev/ondemand/sshobservatory
+{"uuid": "a542444e-8df3-47b5-a2b8-3e1b0f3c6668"}
+```
+  - Observe the target added to the scan queue with: `sls logs -f onDemandSshObservatoryScan`
 
 - Verify the queued scans actually run: `sls logs -f RunScanQueue`
 ```

--- a/handler.py
+++ b/handler.py
@@ -166,19 +166,34 @@ def runScanFromQ(event, context):
     os.environ['PATH'] = original_pathvar
 
 
-def addScheduledObservatoryScansToQueue(event, context):
+def addScheduledHttpObservatoryScansToQueue(event, context):
     hosts = Hosts()
     hostname_list = hosts.getList()
     for hostname in hostname_list:
         SQS_CLIENT.send_message(
             QueueUrl=os.getenv('SQS_URL'),
             DelaySeconds=2,
-            MessageBody="observatory|" + hostname
+            MessageBody="httpobservatory|" + hostname
             + "|"
         )
-        logger.info("Tasking observatory scan of: " + hostname)
+        logger.info("Tasking http observatory scan of: " + hostname)
 
-    logger.info("Host list has been added to the queue for observatory scan.")
+    logger.info("Host list has been added to the queue for http observatory scan.")
+
+
+def addScheduledSshObservatoryScansToQueue(event, context):
+    hosts = Hosts()
+    hostname_list = hosts.getList()
+    for hostname in hostname_list:
+        SQS_CLIENT.send_message(
+            QueueUrl=os.getenv('SQS_URL'),
+            DelaySeconds=2,
+            MessageBody="sshobservatory|" + hostname
+            + "|"
+        )
+        logger.info("Tasking ssh observatory scan of: " + hostname)
+
+    logger.info("Host list has been added to the queue for ssh observatory scan.")
 
 
 def putInQueue(event, context):

--- a/serverless.yml
+++ b/serverless.yml
@@ -61,11 +61,18 @@ functions:
           method: POST
           cors: true
           private: ${self:custom.cfg.private}
-  onDemandObservatoryScan:
-    handler: handler.addObservatoryScanToQueue
+  onDemandHttpObservatoryScan:
+    handler: handler.addHttpObservatoryScanToQueue
     events:
       - http:
-          path: ondemand/observatory
+          path: ondemand/httpobservatory
+          method: POST
+          cors: true
+  onDemandSshObservatoryScan:
+    handler: handler.addSshObservatoryScanToQueue
+    events:
+      - http:
+          path: ondemand/sshobservatory
           method: POST
           cors: true
   cronPortScan:

--- a/serverless.yml
+++ b/serverless.yml
@@ -85,8 +85,17 @@ functions:
           rate: cron(0 18 ? * WED *)
           # Not enabling this by default as it is intrusive in nature
           enabled: false
-  cronObservatoryScan:
-    handler: handler.addScheduledObservatoryScansToQueue
+  cronHttpObservatoryScan:
+    handler: handler.addScheduledHttpObservatoryScansToQueue
+    timeout: 60
+    events:
+      # Invoke Lambda function once a day
+      # Run at 4 PM UTC every day
+      - schedule: 
+          rate: cron(0 16 * * ? *)
+          enabled: true
+  cronSshObservatoryScan:
+    handler: handler.addScheduledSshObservatoryScansToQueue
     timeout: 60
     events:
       # Invoke Lambda function once a day

--- a/tests/test_ssh_observatory_scanner.py
+++ b/tests/test_ssh_observatory_scanner.py
@@ -1,0 +1,46 @@
+import sys
+import pytest
+import os
+import json
+import requests
+from scanners.ssh_observatory_scanner import SSHObservatoryScanner
+from lib.target import Target
+
+
+class TestSSHObservatoryScanner():
+    def test_defaults(self):
+        scanner = SSHObservatoryScanner()
+        assert scanner.poll_interval == 1
+        assert scanner.api_url == None
+
+    def test_setting_poll_interval(self):
+        scanner = SSHObservatoryScanner(2)
+        assert scanner.poll_interval == 2
+        assert scanner.api_url == None
+
+    def test_setting_api_url(self):
+        # Stub env var for testing
+        os.environ["SSHOBS_API_URL"] = "https://sshscan.rubidus.com"
+
+        scanner = SSHObservatoryScanner()
+        assert scanner.poll_interval == 1
+        assert scanner.api_url == os.environ["SSHOBS_API_URL"]
+
+        # Unstub env var for testing
+        os.environ["SSHOBS_API_URL"] = ""
+
+    def test_scan(self):
+        # Stub env var for testing
+        os.environ["SSHOBS_API_URL"] = "https://sshscan.rubidus.com"
+        host_name = "ssh.mozilla.com"
+        scanner = SSHObservatoryScanner()
+        scan_result = scanner.scan(host_name)
+
+        # Check to see is some of the expected JSON elements
+        # are in the scan result to ensure it's working
+        assert 'ssh_scan_version' in scan_result['scan']
+        assert 'ip' in scan_result['scan']
+        assert 'hostname' in scan_result['scan']
+
+        # Unstub env var for testing
+        os.environ["SSHOBS_API_URL"] = ""


### PR DESCRIPTION
Mocks up the base class and tests for an  SSH  Observatory  scanner.  Does not include integration into the framework or associated future REST endpoints.