### PR TITLE
Refactoring portscan handler out of handler and mocking it with moto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
 python:
   - "3.6"
-# command to install dependencies
+before_install:
+  - export BOTO_CONFIG=/dev/null
 install:
   - pip install -r requirements.txt
+  # This is a workaround for issue: https://github.com/spulec/moto/issues/1941
+  - pip install -e git+https://github.com/spulec/moto@master#egg=moto
 # command to run tests
 script:
-- PYTHONPATH=. pytest tests/
+- PYTHONPATH=. python3 -m pytest tests/

--- a/examples/realtime_ctlog_tasker.py
+++ b/examples/realtime_ctlog_tasker.py
@@ -35,9 +35,13 @@ def print_callback(message, context):
                     logger.info("Sends POST to https://<YOUR-API-ENDPOINT>/dev/ondemand/portscan")
                     logger.info("Triggered a Port Scan of: {}".format(fqdn))
 
-                    # TODO: add relevant tasking call here to /ondemand/observatoryscan
-                    logger.info("Sends POST to https://<YOUR-API-ENDPOINT>/dev/ondemand/observatory")
-                    logger.info("Triggered an Observatory Scan of: {}".format(fqdn))
+                    # TODO: add relevant tasking call here to /ondemand/httpobservatoryscan
+                    logger.info("Sends POST to https://<YOUR-API-ENDPOINT>/dev/ondemand/httpobservatory")
+                    logger.info("Triggered an HTTP Observatory Scan of: {}".format(fqdn))
+
+                    # TODO: add relevant tasking call here to /ondemand/sshobservatoryscan
+                    logger.info("Sends POST to https://<YOUR-API-ENDPOINT>/dev/ondemand/sshobservatory")
+                    logger.info("Triggered an SSH Observatory Scan of: {}".format(fqdn))
 
 
 logging.basicConfig(format='[%(levelname)s:%(name)s] %(asctime)s - %(message)s', level=logging.INFO)

--- a/handler.py
+++ b/handler.py
@@ -11,58 +11,9 @@ from lib.response import Response
 from scanners.http_observatory_scanner import HTTPObservatoryScanner
 from lib.hosts import Hosts
 
-
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 SQS_CLIENT = boto3.client('sqs')
-
-
-def addPortScanToQueue(event, context):
-    data = json.loads(event['body'])
-    if "target" not in data:
-        logger.error("Unrecognized payload")
-        return Response({
-            "statusCode": 500,
-            "body": json.dumps({'error': 'Unrecognized payload'})
-        }).with_security_headers()
-
-    target = Target(data.get('target'))
-    if not target:
-        logger.error("Target validation failed of: " +
-                     target.name)
-        return Response({
-            "statusCode": 400,
-            "body": json.dumps({'error': 'Target was not valid or missing'})
-        }).with_security_headers()
-
-    scan_uuid = str(uuid.uuid4())
-    print(SQS_CLIENT.send_message(
-        QueueUrl=os.getenv('SQS_URL'),
-        MessageBody="portscan|" + target.name
-        + "|" + scan_uuid
-    ))
-
-    # Use a UUID for the scan type and return it
-    return Response({
-        "statusCode": 200,
-        "body": json.dumps({'uuid': scan_uuid})
-    }).with_security_headers()
-
-
-def addScheduledPortScansToQueue(event, context):
-
-    hosts = Hosts()
-    hostname_list = hosts.getList()
-    for hostname in hostname_list:
-        SQS_CLIENT.send_message(
-            QueueUrl=os.getenv('SQS_URL'),
-            DelaySeconds=2,
-            MessageBody="portscan|" + hostname
-            + "|"
-        )
-        logger.info("Tasking port scan of: " + hostname)
-
-    logger.info("Host list has been added to the queue for port scan.")
 
 
 def addHttpObservatoryScanToQueue(event, context):

--- a/lib/portscan_handler.py
+++ b/lib/portscan_handler.py
@@ -1,0 +1,61 @@
+import uuid
+import logging
+import boto3
+import json
+import os
+
+from lib.target import Target
+from lib.response import Response
+from lib.hosts import Hosts
+
+
+class PortScanHandler(object):
+    def __init__(self, sqs_client=boto3.client('sqs', region_name='us-west-2'), logger=logging.getLogger(__name__), region='us-west-2'):
+        self.sqs_client = sqs_client
+        self.logger = logger
+        self.region = region
+
+    def queue(self, event, context):
+        data = json.loads(event['body'])
+        if "target" not in data:
+            self.logger.error("Unrecognized payload")
+            return Response({
+                "statusCode": 500,
+                "body": json.dumps({'error': 'Unrecognized payload'})
+            }).with_security_headers()
+
+        target = Target(data.get('target'))
+        if not target:
+            self.logger.error("Target validation failed of: " +
+                              target.name)
+            return Response({
+                "statusCode": 400,
+                "body": json.dumps({'error': 'Target was not valid or missing'})
+            }).with_security_headers()
+
+        scan_uuid = str(uuid.uuid4())
+        print(self.sqs_client.send_message(
+            QueueUrl=os.getenv('SQS_URL'),
+            MessageBody="portscan|" + target.name
+            + "|" + scan_uuid
+        ))
+
+        # Use a UUID for the scan type and return it
+        return Response({
+            "statusCode": 200,
+            "body": json.dumps({'uuid': scan_uuid})
+        }).with_security_headers()
+
+    def queue_scheduled(self, event, context):
+        hosts = Hosts()
+        hostname_list = hosts.getList()
+        for hostname in hostname_list:
+            self.sqs_client.send_message(
+                QueueUrl=os.getenv('SQS_URL'),
+                DelaySeconds=2,
+                MessageBody="portscan|" + hostname
+                + "|"
+            )
+            self.logger.info("Tasking port scan of: " + hostname)
+
+        self.logger.info("Host list has been added to the queue for port scan.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 netaddr==0.7.19
 requests>=2.20.0
 python_nmap==0.6.1
-boto3==1.9.109
+boto3>=1.9.109
 pytest>=4.1.1
+moto>=1.3.7
+certstream>=1.10

--- a/tests/test_portscan_handler.py
+++ b/tests/test_portscan_handler.py
@@ -1,0 +1,18 @@
+import sys
+import pytest
+import os
+import json
+from lib.portscan_handler import PortScanHandler
+
+
+class TestPortScanHandler():
+    def test_creation(self):
+        port_scan_handler = PortScanHandler()
+        assert type(port_scan_handler) is PortScanHandler
+
+    def test_queue(self):
+        test_event = {"body": '{"target": "ssh.mozilla.com"}'}
+        test_context = None
+        port_scan_handler = PortScanHandler()
+        response = port_scan_handler.queue(test_event, test_context)
+        assert response.response_dict == {}

--- a/tests/test_portscan_handler.py
+++ b/tests/test_portscan_handler.py
@@ -1,18 +1,70 @@
 import sys
 import pytest
 import os
+import boto3
 import json
+import time
+
 from lib.portscan_handler import PortScanHandler
+from lib.hosts import Hosts
+from moto import mock_sqs
+from uuid import UUID
 
 
 class TestPortScanHandler():
+    @pytest.fixture
+    def sqs(self, scope="session", autouse=True):
+        mock = mock_sqs()
+        mock.start()
+        # There is currently a bug on moto, this line is needed as a workaround
+        # Ref: https://github.com/spulec/moto/issues/1926
+        boto3.setup_default_session()
+
+        sqs_client = boto3.client('sqs', 'us-west-2')
+        queue_name = "test-scan-queue"
+        queue_url = sqs_client.create_queue(
+            QueueName=queue_name
+        )['QueueUrl']
+
+        yield (sqs_client, queue_url)
+        mock.stop()
+
     def test_creation(self):
         port_scan_handler = PortScanHandler()
         assert type(port_scan_handler) is PortScanHandler
 
-    def test_queue(self):
+    def test_queue(self, sqs):
+        client, queue_url = sqs
         test_event = {"body": '{"target": "ssh.mozilla.com"}'}
         test_context = None
-        port_scan_handler = PortScanHandler()
-        response = port_scan_handler.queue(test_event, test_context)
-        assert response.response_dict == {}
+        port_scan_handler = PortScanHandler(client, queue_url)
+        port_scan_handler.queue(test_event, test_context)
+        response = client.receive_message(QueueUrl=queue_url)
+        scan_type, target, uuid = response['Messages'][0]['Body'].split('|')
+        assert scan_type == "portscan"
+        assert target == "ssh.mozilla.com"
+        assert UUID(uuid, version=4)
+
+    def test_queue_scheduled(self, sqs):
+        client, queue_url = sqs
+        test_hostlist = [
+            "ssh.mozilla.com",
+            "infosec.mozilla.org",
+            "mozilla.org"
+        ]
+        index = 0
+        test_event = None
+        test_context = None
+        port_scan_handler = PortScanHandler(client, queue_url)
+        port_scan_handler.queue_scheduled(test_event, test_context, test_hostlist)
+
+        # Need to sleep here for at least 6 seconds as queue messages
+        # have 2 seconds delay until become available
+        time.sleep(7)
+        response = client.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=3)
+        for msg in response['Messages']:
+            scan_type, target, placeholder = msg['Body'].split('|')
+            assert scan_type == "portscan"
+            assert target == test_hostlist[index]
+            assert placeholder == ""
+            index += 1


### PR DESCRIPTION
This is a WIP for moving port_scan logic out of handler into it's own PortScanHandler.

The purpose of doing this is to prevent handler.py from getting massive, and make sure we're able to more easily make progress on extracting functionality without needing to do it whole-hog.