### PR TITLE
Implement TLS Observatory scans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "3.6"
 # command to install dependencies
+before_install:
+  - export BOTO_CONFIG=/dev/null
 install:
   - pip install -r requirements.txt
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - pip install -r requirements.txt
 # command to run tests
 script:
-- PYTHONPATH=. pytest tests/
+- PYTHONPATH=. python3 -m pytest tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ before_install:
   - export BOTO_CONFIG=/dev/null
 install:
   - pip install -r requirements.txt
+  # This is a workaround for issue: https://github.com/spulec/moto/issues/1941
+  - pip install -e git+https://github.com/spulec/moto@master#egg=moto
 # command to run tests
 script:
 - PYTHONPATH=. python3 -m pytest tests/

--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@ This project uses serverless framework and attempts to create a serverless envir
 
 This is under development with more features being added as different branches. The current branch supports:
 - Addition of a target to the scan queue for port scan by an API endpoint (`/ondemand/portscan`). Due to the intrusive nature of this endpoint, it is protected by an API key.
-- Addition of a target to the scan queue for Observatory scan by an API endpoint (`/ondemand/observatory`)
-- Performing requested scan type (port or Observatory) on hosts in the queue
-- Daily scheduled port scans from a hard-coded list of hosts (for PoC purposes, currently disabled)
-- Scheduled HTTP Observatory scans from a hard-coded list of hosts (for PoC purposes, runs every 5 minutes)
-- Manually add a host to the queue (for PoC purposes).
+- Addition of a target to the scan queue for HTTP Observatory scan by an API endpoint (`/ondemand/httpobservatory`)
+- Addition of a target to the scan queue for TLS Observatory scan by an API endpoint (`/ondemand/tlsobservatory`)
+- Addition of a target to the scan queue for SSH Observatory scan by an API endpoint (`/ondemand/sshobservatory`)
+- Performing requested scan type (port, HTTP Observatory,  TLS Observatory or SSH Observatory) on hosts in the queue
+- Scheduled port scans from a hard-coded list of hosts (for PoC purposes, currently disabled)
+- Scheduled HTTP Observatory scans from a hard-coded list of hosts (for PoC purposes, runs once a day)
+- Scheduled TLS Observatory scans from a hard-coded list of hosts (for PoC purposes, runs once a day)
+- Scheduled SSH Observatory scans from a hard-coded list of hosts (for PoC purposes, runs once a day)
+- Manually add a host to the scan queue (for PoC purposes).
 
 Results from all scans are placed in an S3 bucket specified in `serverless.yml`.
 
@@ -29,7 +33,7 @@ _**Note:** UDP port scans are not supported as Lamdba functions can not be as ro
 
 ## Running
 
-- Scheduled Observatory scans will run every 5 mins: `serverless logs -f cronObservatoryScan`
+- Scheduled Observatory scans will run once a day: `serverless logs -f cronHttpObservatoryScan`
 
 ```
 START RequestId: 6a3bc71b-e369-498c-849c-f522e79ce734 Version: $LATEST
@@ -52,10 +56,17 @@ curl -X POST -d '{"target": "www.smh.com.au"}' https://<YOUR-API-ENDPOINT>/dev/o
 
 - To kick off an SSH Observatory scan on a target on demand:
 ```
-curl -X POST -d '{"target": "www.smh.com.au"}' https://<YOUR-API-ENDPOINT>/dev/ondemand/sshobservatory
+curl -X POST -d '{"target": "www.mozilla.org"}' https://<YOUR-API-ENDPOINT>/dev/ondemand/sshobservatory
 {"uuid": "a542444e-8df3-47b5-a2b8-3e1b0f3c6668"}
 ```
   - Observe the target added to the scan queue with: `sls logs -f onDemandSshObservatoryScan`
+
+- To kick off a TLS Observatory scan on a target on demand:
+```
+curl -X POST -d '{"target": "www.mozilla.org"}' https://<YOUR-API-ENDPOINT>/dev/ondemand/tlsobservatory
+{"uuid": "a542444e-8df3-47b5-a2b8-3e1b0f3c6668"}
+```
+  - Observe the target added to the scan queue with: `sls logs -f onDemandTlsObservatoryScan`
 
 - Verify the queued scans actually run: `sls logs -f RunScanQueue`
 ```
@@ -74,6 +85,7 @@ $ aws s3 ls s3://<your-bucket-name>
 2019-03-12 22:27:00       9209 www.mozilla.org_httpobservatory.json
 2019-03-12 22:27:00       9209 www.mozilla.org_sshobservatory.json
 2019-03-07 16:41:27       5630 www.smh.com.au_tcpscan.json
-2019-03-12 22:49:33       5697 www.smh.com.au_org_httpobservatory.json
-2019-03-12 22:49:33       5697 www.smh.com.au_org_sshobservatory.json
+2019-03-12 22:49:33       5697 www.smh.com.au_httpobservatory.json
+2019-03-12 22:49:33       5697 www.smh.com.au_sshobservatory.json
+2019-03-17 20:42:54       5697 www.mozilla.org_tlsobservatory.json
 ```

--- a/examples/ondemand_tasker.py
+++ b/examples/ondemand_tasker.py
@@ -4,12 +4,21 @@ import datetime
 import json
 
 # This is an example of an on demand scan that an engineer might run should they have
-# interest in getting immediate vulnerability data about a given FQDN.  This would be
+# interest in getting immediate vulnerability data about a given FQDN. This would be
 # the interface an engineer could use to kick off a VA.
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 fqdn = input("Provide the FQDN (Fully Qualified Domain Name) you want to scan: ")
-# TODO: add relevant tasking call here to /ondemand/portscan, /ondemand/observatory, etc.
-logger.info("Triggered a vulnerability scan of: {}".format(fqdn))
+# TODO: add relevant tasking call here to /ondemand/portscan
+logger.info("Sends POST to https://<YOUR-API-ENDPOINT>/dev/ondemand/portscan")
+logger.info("Triggered a Port Scan of: {}".format(fqdn))
+
+# TODO: add relevant tasking call here to /ondemand/httpobservatoryscan
+logger.info("Sends POST to https://<YOUR-API-ENDPOINT>/dev/ondemand/httpobservatory")
+logger.info("Triggered an HTTP Observatory Scan of: {}".format(fqdn))
+
+# TODO: add relevant tasking call here to /ondemand/tlsobservatoryscan
+logger.info("Sends POST to https://<YOUR-API-ENDPOINT>/dev/ondemand/tlsobservatory")
+logger.info("Triggered an SSH Observatory Scan of: {}".format(fqdn))

--- a/examples/realtime_ctlog_tasker.py
+++ b/examples/realtime_ctlog_tasker.py
@@ -35,9 +35,13 @@ def print_callback(message, context):
                     logger.info("Sends POST to https://<YOUR-API-ENDPOINT>/dev/ondemand/portscan")
                     logger.info("Triggered a Port Scan of: {}".format(fqdn))
 
-                    # TODO: add relevant tasking call here to /ondemand/observatoryscan
-                    logger.info("Sends POST to https://<YOUR-API-ENDPOINT>/dev/ondemand/observatory")
+                    # TODO: add relevant tasking call here to /ondemand/httpobservatory
+                    logger.info("Sends POST to https://<YOUR-API-ENDPOINT>/dev/ondemand/httpobservatory")
                     logger.info("Triggered an Observatory Scan of: {}".format(fqdn))
+
+                    # TODO: add relevant tasking call here to /ondemand/tlsobservatoryscan
+                    logger.info("Sends POST to https://<YOUR-API-ENDPOINT>/dev/ondemand/tlsobservatory")
+                    logger.info("Triggered an SSH Observatory Scan of: {}".format(fqdn))
 
 
 logging.basicConfig(format='[%(levelname)s:%(name)s] %(asctime)s - %(message)s', level=logging.INFO)

--- a/handler.py
+++ b/handler.py
@@ -6,9 +6,11 @@ import uuid
 
 from lib.s3_helper import send_to_s3
 from lib.target import Target
-from scanners.port_scanner import PortScanner
 from lib.response import Response
 from scanners.http_observatory_scanner import HTTPObservatoryScanner
+from scanners.ssh_observatory_scanner import SSHObservatoryScanner
+from scanners.tls_observatory_scanner import TLSObservatoryScanner
+from scanners.port_scanner import PortScanner
 from lib.hosts import Hosts
 
 
@@ -149,6 +151,10 @@ def runScanFromQ(event, context):
                     scanner = SSHObservatoryScanner()
                     scan_result = scanner.scan(target)
                     send_to_s3(target + "_sshobservatory", scan_result)
+                elif scan_type == "tlsobservatory":
+                    scanner = TLSObservatoryScanner()
+                    scan_result = scanner.scan(target)
+                    send_to_s3(target + "_tlsobservatory", scan_result)
                 elif scan_type == "portscan":
                     scanner = PortScanner(target)
                     nmap_scanner = scanner.scanTCP()

--- a/lib/tlsobsscan_handler.py
+++ b/lib/tlsobsscan_handler.py
@@ -3,15 +3,15 @@ import logging
 import boto3
 import json
 import os
-
 from lib.target import Target
 from lib.response import Response
 from lib.hosts import Hosts
 
 
 class TLSObsScanHandler(object):
-    def __init__(self, sqs_client=boto3.client('sqs', region_name='us-west-2'), logger=logging.getLogger(__name__), region='us-west-2'):
+    def __init__(self, sqs_client=boto3.client('sqs', region_name='us-west-2'), queueURL=os.getenv('SQS_URL'), logger=logging.getLogger(__name__), region='us-west-2'):
         self.sqs_client = sqs_client
+        self.queueURL = queueURL
         self.logger = logger
         self.region = region
 
@@ -35,7 +35,7 @@ class TLSObsScanHandler(object):
 
         scan_uuid = str(uuid.uuid4())
         self.sqs_client.send_message(
-            QueueUrl=os.getenv('SQS_URL'),
+            QueueUrl=self.queueURL,
             MessageBody="tlsobservatory|" + target.name
             + "|" + scan_uuid
         )
@@ -51,7 +51,7 @@ class TLSObsScanHandler(object):
         hostname_list = hosts.getList()
         for hostname in hostname_list:
             self.sqs_client.send_message(
-                QueueUrl=os.getenv('SQS_URL'),
+                QueueUrl=self.queueURL,
                 DelaySeconds=2,
                 MessageBody="tlsobservatory|" + hostname
                 + "|"

--- a/lib/tlsobsscan_handler.py
+++ b/lib/tlsobsscan_handler.py
@@ -46,9 +46,10 @@ class TLSObsScanHandler(object):
             "body": json.dumps({'uuid': scan_uuid})
         }).with_security_headers()
 
-    def queue_scheduled(self, event, context):
-        hosts = Hosts()
-        hostname_list = hosts.getList()
+    def queue_scheduled(self, event, context, hostname_list=[]):
+        if len(hostname_list) == 0:
+            hosts = Hosts()
+            hostname_list = hosts.getList()
         for hostname in hostname_list:
             self.sqs_client.send_message(
                 QueueUrl=self.queueURL,

--- a/lib/tlsobsscan_handler.py
+++ b/lib/tlsobsscan_handler.py
@@ -1,0 +1,62 @@
+import uuid
+import logging
+import boto3
+import json
+import os
+
+from lib.target import Target
+from lib.response import Response
+from lib.hosts import Hosts
+
+
+class TLSObsScanHandler(object):
+    def __init__(self, sqs_client=boto3.client('sqs', region_name='us-west-2'), logger=logging.getLogger(__name__), region='us-west-2'):
+        self.sqs_client = sqs_client
+        self.logger = logger
+        self.region = region
+
+    def queue(self, event, context):
+        data = json.loads(event['body'])
+        if "target" not in data:
+            self.logger.error("Unrecognized payload")
+            return Response({
+                "statusCode": 500,
+                "body": json.dumps({'error': 'Unrecognized payload'})
+            }).with_security_headers()
+
+        target = Target(data.get('target'))
+        if not target:
+            self.logger.error("Target validation failed of: " +
+                              target.name)
+            return Response({
+                "statusCode": 400,
+                "body": json.dumps({'error': 'Target was not valid or missing'})
+            }).with_security_headers()
+
+        scan_uuid = str(uuid.uuid4())
+        self.sqs_client.send_message(
+            QueueUrl=os.getenv('SQS_URL'),
+            MessageBody="tlsobservatory|" + target.name
+            + "|" + scan_uuid
+        )
+
+        # Use a UUID for the scan type and return it
+        return Response({
+            "statusCode": 200,
+            "body": json.dumps({'uuid': scan_uuid})
+        }).with_security_headers()
+
+    def queue_scheduled(self, event, context):
+        hosts = Hosts()
+        hostname_list = hosts.getList()
+        for hostname in hostname_list:
+            self.sqs_client.send_message(
+                QueueUrl=os.getenv('SQS_URL'),
+                DelaySeconds=2,
+                MessageBody="tlsobservatory|" + hostname
+                + "|"
+            )
+            self.logger.info("Tasking TLS observatory scan of: " + hostname)
+
+        self.logger.info("Host list has been added to the queue "
+                         "for TLS observatory scan.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python_nmap==0.6.1
 boto3>=1.9.109
 pytest>=4.1.1
 moto>=1.3.7
+certstream>=1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 netaddr==0.7.19
 requests>=2.20.0
 python_nmap==0.6.1
-boto3==1.9.109
+boto3>=1.9.109
 pytest>=4.1.1
+moto>=1.3.7

--- a/scanners/tls_observatory_scanner.py
+++ b/scanners/tls_observatory_scanner.py
@@ -1,0 +1,38 @@
+import requests
+import time
+import os
+
+
+class TLSObservatoryScanner():
+
+    def __init__(self, poll_interval=1):
+        self.session = requests.Session()
+        self.poll_interval = poll_interval
+        self.api_url = os.getenv('TLSOBS_API_URL')
+
+    def scan(self, hostname):
+        # Initiate the scan
+        if self.api_url[-1] != "/":
+            analyze_url = self.api_url + '/analyze?host=' + hostname
+        else:
+            raise Exception("Invalid API URL specified for Observatory.")
+        results = {}
+        results['scan'] = self.session.post(analyze_url, data=None).json()
+
+        # Wait for the scan to complete, polling every second
+        results['tests'] = self.__poll(results['scan']['scan_id'])
+        results['host'] = hostname
+        return results
+
+    def __poll(self, scan_id):
+        url = self.api_url + '/getScanResults?scan=' + str(scan_id)
+        count = 0
+        while count < 60:
+            resp = self.session.get(url).json()
+            # This means we got our results back, so return them!
+            if 'content-security-policy' in resp:
+                return resp
+
+            time.sleep(self.poll_interval)
+            count += 1
+        raise Exception("Unable to get results within 60 seconds")

--- a/scanners/tls_observatory_scanner.py
+++ b/scanners/tls_observatory_scanner.py
@@ -29,10 +29,10 @@ class TLSObservatoryScanner():
         url = self.api_url + '/results?id=' + str(scan_id)
         completion_percentage = 0
         while completion_percentage != 100:
-            resp = self.session.get(url).json()
+            resp = self.session.get(url)
             # This means we got our results back, so return them!
-            if resp.status_code == 200 and resp['completion_perc'] == 100:
-                return resp
+            if resp.status_code == 200 and resp.json()['completion_perc'] == 100:
+                return resp.json()
 
             time.sleep(self.poll_interval)
             completion_percentage = resp['completion_perc']

--- a/serverless.yml
+++ b/serverless.yml
@@ -33,6 +33,7 @@ provider:
         - Arn
   environment:
     HTTPOBS_API_URL: 'https://http-observatory.security.mozilla.org/api/v1'
+    TLSOBS_API_URL: 'https://tls-observatory.services.mozilla.com/api/v1'
     # Using Observatory list as source list for scheduled scans as it is comprehensive enough
     # This could be updated later, perhaps to another source, such as pentest-master list?
     HOST_LIST: 'https://raw.githubusercontent.com/mozilla/http-observatory-dashboard/master/httpobsdashboard/conf/sites.json'

--- a/serverless.yml
+++ b/serverless.yml
@@ -76,6 +76,13 @@ functions:
           path: ondemand/sshobservatory
           method: POST
           cors: true
+  onDemandTlsObservatoryScan:
+    handler: lib/tlsobsscan_handler.queue
+    events:
+      - http:
+          path: ondemand/tlsobservatory
+          method: POST
+          cors: true 
   cronPortScan:
     handler: handler.addScheduledPortScansToQueue
     timeout: 60
@@ -93,6 +100,15 @@ functions:
       # Invoke Lambda function once a day
       # Run at 4 PM UTC every day
       - schedule: 
+          rate: cron(0 16 * * ? *)
+          enabled: true
+  cronTlsObservatoryScan:
+    handler: lib/tlsobsscan_handler.queue_scheduled
+    timeout: 60
+    events:
+      # Invoke Lambda function once a day
+      # Run at 4 PM UTC every day
+      - schedule:
           rate: cron(0 16 * * ? *)
           enabled: true
   cronSshObservatoryScan:

--- a/tests/test_tls_observatory_scan_handler.py
+++ b/tests/test_tls_observatory_scan_handler.py
@@ -1,0 +1,18 @@
+import sys
+import pytest
+import os
+import json
+from lib.tlsobsscan_handler import TLSObsScanHandler
+
+
+class TestTLSObsScanHandler():
+    def test_creation(self):
+        tlsobs_scan_handler = TLSObsScanHandler()
+        assert type(tlsobs_scan_handler) is TLSObsScanHandler
+
+    def test_queue(self):
+        test_event = {"body": '{"target": "ssh.mozilla.com"}'}
+        test_context = None
+        tlsobs_scan_handler = TLSObsScanHandler()
+        response = tlsobs_scan_handler.queue(test_event, test_context)
+        assert response.response_dict == {}

--- a/tests/test_tls_observatory_scan_handler.py
+++ b/tests/test_tls_observatory_scan_handler.py
@@ -1,18 +1,42 @@
-import sys
+
 import pytest
-import os
-import json
+import boto3
 from lib.tlsobsscan_handler import TLSObsScanHandler
+from moto import mock_sqs
+from uuid import UUID
 
 
 class TestTLSObsScanHandler():
+    @pytest.fixture
+    def sqs(self, scope="session", autouse=True):
+        mock = mock_sqs()
+        mock.start()
+        # There is currently a bug on moto, this line is needed as a workaround
+        # Ref: https://github.com/spulec/moto/issues/1926
+        boto3.setup_default_session()
+
+        sqs_client = boto3.client('sqs', 'us-west-2')
+        queue_name = "test-scan-queue"
+        queue_url = sqs_client.create_queue(
+            QueueName=queue_name
+        )['QueueUrl']
+
+        yield (sqs_client, queue_url)
+        mock.stop()
+
     def test_creation(self):
         tlsobs_scan_handler = TLSObsScanHandler()
         assert type(tlsobs_scan_handler) is TLSObsScanHandler
 
-    def test_queue(self):
+    def test_queue(self, sqs):
+        client, queue_url = sqs
         test_event = {"body": '{"target": "ssh.mozilla.com"}'}
         test_context = None
-        tlsobs_scan_handler = TLSObsScanHandler()
-        response = tlsobs_scan_handler.queue(test_event, test_context)
-        assert response.response_dict == {}
+        tlsobs_scan_handler = TLSObsScanHandler(client, queue_url)
+        tlsobs_scan_handler.queue(test_event, test_context)
+        response = client.receive_message(QueueUrl=queue_url)
+        scan_type, target, uuid = response['Messages'][0]['Body'].split('|')
+        assert scan_type == "tlsobservatory"
+        assert target == "ssh.mozilla.com"
+        assert UUID(uuid, version=4)
+

--- a/tests/test_tls_observatory_scanner.py
+++ b/tests/test_tls_observatory_scanner.py
@@ -1,0 +1,47 @@
+
+import pytest
+import os
+import requests
+from scanners.tls_observatory_scanner import TLSObservatoryScanner
+
+
+class TestTLSObservatoryScanner():
+    def test_defaults(self):
+        scanner = TLSObservatoryScanner()
+        assert scanner.poll_interval == 1
+        # This is expected to be None because the API value lives
+        # in Serverless Lambda environment, not locally
+        assert scanner.api_url == None
+
+    def test_setting_poll_interval(self):
+        scanner = TLSObservatoryScanner(2)
+        assert scanner.poll_interval == 2
+        # Same as above function
+        assert scanner.api_url == None
+
+    def test_setting_api_url(self):
+        # Stub env var for testing
+        os.environ["TLSOBS_API_URL"] = "https://tls-observatory.services.mozilla.com/api/v1"
+
+        scanner = TLSObservatoryScanner()
+        assert scanner.poll_interval == 1
+        assert scanner.api_url == os.environ["TLSOBS_API_URL"]
+
+        # Unstub env var for testing
+        os.environ["TLSOBS_API_URL"] = ""
+
+    def test_scan(self):
+        # Stub env var for testing
+        os.environ["TLSOBS_API_URL"] = "https://tls-observatory.services.mozilla.com/api/v1"
+        host_name = "www.mozilla.org"
+        scanner = TLSObservatoryScanner()
+        scan_result = scanner.scan(host_name)
+
+        # Check to see is some of the expected JSON elements
+        # are in the scan result to ensure it's working
+        assert 'host' in scan_result
+        assert 'scan' in scan_result
+        assert 'completion_perc' in scan_result['scan']
+
+        # Unstub env var for testing
+        os.environ["TLSOBS_API_URL"] = ""


### PR DESCRIPTION
This uses dedicated handlers (as experimented in https://github.com/mozilla/vautomator-serverless/pull/18) as well as test classes for them, using `moto`.

It's a work in progress, as tests for performing the actual TLS scan is not implemented yet.