### PR TITLE
Add dedicated handler for SSH scanner and its tests

### DIFF
--- a/lib/sshscan_handler.py
+++ b/lib/sshscan_handler.py
@@ -1,0 +1,67 @@
+import uuid
+import logging
+import boto3
+import json
+import os
+
+from lib.target import Target
+from lib.response import Response
+from lib.hosts import Hosts
+
+
+class SSHScanHandler(object):
+    def __init__(self, sqs_client=boto3.client('sqs', region_name='us-west-2'), queueURL=os.getenv('SQS_URL'), logger=logging.getLogger(__name__), region='us-west-2'):
+        self.sqs_client = sqs_client
+        self.logger = logger
+        self.queueURL = queueURL
+        self.region = region
+
+    def queue(self, event, context):
+        data = json.loads(event['body'])
+        if "target" not in data:
+            self.logger.error("Unrecognized payload")
+            return Response({
+                "statusCode": 500,
+                "body": json.dumps({'error': 'Unrecognized payload'})
+            }).with_security_headers()
+
+        target = Target(data.get('target'))
+        if not target:
+            self.logger.error("Target validation failed of: " +
+                              target.name)
+            return Response({
+                "statusCode": 400,
+                "body": json.dumps({'error': 'Target was not valid or missing'})
+            }).with_security_headers()
+
+        scan_uuid = str(uuid.uuid4())
+
+        self.sqs_client.send_message(
+            QueueUrl=self.queueURL,
+            MessageBody="sshobservatory|" + target.name
+            + "|" + scan_uuid
+        )
+
+        # Use a UUID for the scan type and return it
+        return Response({
+            "statusCode": 200,
+            "body": json.dumps({'uuid': scan_uuid})
+        }).with_security_headers()
+
+    def queue_scheduled(self, event, context, hostname_list=[]):
+        if len(hostname_list) == 0:
+            hosts = Hosts()
+            hostname_list = hosts.getList()
+
+        for hostname in hostname_list:
+
+            self.sqs_client.send_message(
+                QueueUrl=self.queueURL,
+                DelaySeconds=2,
+                MessageBody="sshobservatory|" + hostname
+                + "|"
+            )
+            self.logger.info("Tasking SSH observatory scan of: " + hostname)
+
+        self.logger.info("Host list has been added to the queue for SSH observatory scan.")
+        

--- a/serverless.yml
+++ b/serverless.yml
@@ -70,7 +70,7 @@ functions:
           method: POST
           cors: true
   onDemandSshObservatoryScan:
-    handler: handler.addSshObservatoryScanToQueue
+    handler: lib/sshscan_handler.queue
     events:
       - http:
           path: ondemand/sshobservatory
@@ -112,7 +112,7 @@ functions:
           rate: cron(0 16 * * ? *)
           enabled: true
   cronSshObservatoryScan:
-    handler: handler.addScheduledSshObservatoryScansToQueue
+    handler: lib/sshscan_handler.queue_scheduled
     timeout: 60
     events:
       # Invoke Lambda function once a day

--- a/tests/test_ssh_observatory_scan_handler.py
+++ b/tests/test_ssh_observatory_scan_handler.py
@@ -1,0 +1,71 @@
+import pytest
+import boto3
+import time
+
+from lib.sshscan_handler import SSHScanHandler
+from lib.hosts import Hosts
+from moto import mock_sqs
+from uuid import UUID
+
+
+class TestSSHScanHandler():
+    @pytest.fixture
+    def sqs(self, scope="session", autouse=True):
+        mock = mock_sqs()
+        mock.start()
+        # There is currently a bug on moto, this line is needed as a workaround
+        # Ref: https://github.com/spulec/moto/issues/1926
+        boto3.setup_default_session()
+
+        sqs_client = boto3.client('sqs', 'us-west-2')
+        queue_name = "test-scan-queue"
+        queue_url = sqs_client.create_queue(
+            QueueName=queue_name
+        )['QueueUrl']
+
+        yield (sqs_client, queue_url)
+        mock.stop()
+
+    def test_creation(self):
+        sshscan_handler = SSHScanHandler()
+        assert type(sshscan_handler) is SSHScanHandler
+
+    def test_queue(self, sqs):
+        client, queue_url = sqs
+        test_event = {"body": '{"target": "ssh.mozilla.com"}'}
+        test_context = None
+        sshscan_handler = SSHScanHandler(client, queue_url)
+        sshscan_handler.queue(test_event, test_context)
+        response = client.receive_message(QueueUrl=queue_url)
+        scan_type, target, uuid = response['Messages'][0]['Body'].split('|')
+        assert scan_type == "sshobservatory"
+        assert target == "ssh.mozilla.com"
+        assert UUID(uuid, version=4)
+
+    def test_queue_scheduled(self, sqs):
+        client, queue_url = sqs
+        test_hostlist = [
+            "ssh.mozilla.com",
+            "infosec.mozilla.org",
+            "mozilla.org"
+        ]
+        index = 0
+        test_event = None
+        test_context = None
+        sshscan_handler = SSHScanHandler(client, queue_url)
+        sshscan_handler.queue_scheduled(test_event,
+                                        test_context,
+                                        test_hostlist)
+
+        # Need to sleep here for at least 6 seconds as queue messages
+        # have 2 seconds delay until become available
+        time.sleep(7)
+        response = client.receive_message(QueueUrl=queue_url,
+                                          MaxNumberOfMessages=3)
+        for msg in response['Messages']:
+            scan_type, target, placeholder = msg['Body'].split('|')
+            assert scan_type == "sshobservatory"
+            assert target == test_hostlist[index]
+            assert placeholder == ""
+            index += 1
+            


### PR DESCRIPTION
I realised a dedicated handler for SSH scanner was missing, so I added and its tests.

With this all implemented scan types follow the same pattern.