### PR TITLE
Use single handler file in project root

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -4,6 +4,10 @@ import os
 
 from lib.s3_helper import send_to_s3
 from lib.target import Target
+from lib.portscan_handler import PortScanHandler
+from lib.httpobsscan_handler import HTTPObsScanHandler
+from lib.tlsobsscan_handler import TLSObsScanHandler
+from lib.sshscan_handler import SSHScanHandler
 from scanners.http_observatory_scanner import HTTPObservatoryScanner
 from scanners.ssh_observatory_scanner import SSHObservatoryScanner
 from scanners.tls_observatory_scanner import TLSObservatoryScanner
@@ -15,6 +19,52 @@ logger.setLevel(logging.INFO)
 SQS_CLIENT = boto3.client('sqs')
 
 
+def queue_portscan(event, context):
+    port_scan_handler = PortScanHandler(sqs_client=SQS_CLIENT, logger=logger)
+    response = port_scan_handler.queue(event, context)
+    return response
+
+
+def queue_scheduled_portscan(event, context):
+    scheduled_portscan_handler = PortScanHandler(sqs_client=SQS_CLIENT, logger=logger)
+    scheduled_portscan_handler.queue_scheduled(event, context)
+
+
+def queue_httpboservatory(event, context):
+    httpobservatory_handler = HTTPObsScanHandler(sqs_client=SQS_CLIENT, logger=logger)
+    response = httpobservatory_handler.queue(event, context)
+    return response
+
+
+def queue_scheduled_httpobservatory(event, context):
+    scheduled_httpobservatory_handler = HTTPObsScanHandler(sqs_client=SQS_CLIENT, logger=logger)
+    scheduled_httpobservatory_handler.queue_scheduled(event, context)
+
+
+def queue_tlsobservatory(event, context):
+    tlsobservatory_handler = TLSObsScanHandler(sqs_client=SQS_CLIENT, logger=logger)
+    response = tlsobservatory_handler.queue(event, context)
+    return response
+
+
+def queue_scheduled_tlsobservatory(event, context):
+    scheduled_tlsobservatory_handler = TLSObsScanHandler(sqs_client=SQS_CLIENT, logger=logger)
+    scheduled_tlsobservatory_handler.queue_scheduled(event, context)
+
+
+def queue_sshobservatory(event, context):
+    sshobservatory_handler = SSHScanHandler(sqs_client=SQS_CLIENT, logger=logger)
+    response = sshobservatory_handler.queue(event, context)
+    return response
+
+
+def queue_scheduled_sshobservatory(event, context):
+    scheduled_sshobservatory_handler = SSHScanHandler(sqs_client=SQS_CLIENT, logger=logger)
+    scheduled_sshobservatory_handler.queue_scheduled(event, context)
+
+
+# To leave handler as lean as possible, we should
+# probably move this to another file/module also
 def runScanFromQ(event, context):
 
     # This is needed for nmap static library to be added to the path

--- a/scanners/ssh_observatory_scanner.py
+++ b/scanners/ssh_observatory_scanner.py
@@ -13,7 +13,7 @@ class SSHObservatoryScanner():
     def scan(self, hostname):
         # Initiate the scan
         if self.api_url[-1] != "/":
-            analyze_url = self.api_url + '/api/v1/scan?target=' + hostname
+            analyze_url = self.api_url + '/scan?target=' + hostname
         else:
             raise Exception("Invalid API URL specified for Observatory.")
         results = {}
@@ -25,7 +25,7 @@ class SSHObservatoryScanner():
         return results
 
     def __poll(self, scan_id):
-        url = self.api_url + '/api/v1/scan/results?uuid=' + str(scan_id)
+        url = self.api_url + '/scan/results?uuid=' + str(scan_id)
         count = 0
         while count < 60:
             resp = self.session.get(url).json()

--- a/serverless.yml
+++ b/serverless.yml
@@ -55,7 +55,7 @@ package:
 
 functions:
   onDemandPortScan:
-    handler: lib/portscan_handler.queue
+    handler: handler.queue_portscan
     events:
       - http:
           path: ondemand/portscan
@@ -63,28 +63,28 @@ functions:
           cors: true
           private: ${self:custom.cfg.private}
   onDemandHttpObservatoryScan:
-    handler: lib/httpobsscan_handler.queue
+    handler: handler.queue_httpboservatory
     events:
       - http:
           path: ondemand/httpobservatory
           method: POST
           cors: true
   onDemandSshObservatoryScan:
-    handler: lib/sshscan_handler.queue
+    handler: handler.queue_sshobservatory
     events:
       - http:
           path: ondemand/sshobservatory
           method: POST
           cors: true
   onDemandTlsObservatoryScan:
-    handler: lib/tlsobsscan_handler.queue
+    handler: handler.queue_tlsobservatory
     events:
       - http:
           path: ondemand/tlsobservatory
           method: POST
           cors: true 
   cronPortScan:
-    handler: lib/portscan_handler.queue_scheduled
+    handler: handler.queue_scheduled_portscan
     timeout: 60
     events:
       # Invoke Lambda function once a week
@@ -94,7 +94,7 @@ functions:
           # Not enabling this by default as it is intrusive in nature
           enabled: false
   cronHttpObservatoryScan:
-    handler: lib/httpobsscan_handler.queue_scheduled
+    handler: handler.queue_scheduled_httpobservatory
     timeout: 60
     events:
       # Invoke Lambda function once a day
@@ -103,7 +103,7 @@ functions:
           rate: cron(0 16 * * ? *)
           enabled: true
   cronTlsObservatoryScan:
-    handler: lib/tlsobsscan_handler.queue_scheduled
+    handler: handler.queue_scheduled_tlsobservatory
     timeout: 60
     events:
       # Invoke Lambda function once a day
@@ -112,7 +112,7 @@ functions:
           rate: cron(0 16 * * ? *)
           enabled: true
   cronSshObservatoryScan:
-    handler: lib/sshscan_handler.queue_scheduled
+    handler: handler.queue_scheduled_sshobservatory
     timeout: 60
     events:
       # Invoke Lambda function once a day

--- a/serverless.yml
+++ b/serverless.yml
@@ -34,6 +34,7 @@ provider:
   environment:
     HTTPOBS_API_URL: 'https://http-observatory.security.mozilla.org/api/v1'
     TLSOBS_API_URL: 'https://tls-observatory.services.mozilla.com/api/v1'
+    SSHOBS_API_URL: 'https://sshscan.rubidus.com/api/v1'
     # Using Observatory list as source list for scheduled scans as it is comprehensive enough
     # This could be updated later, perhaps to another source, such as pentest-master list?
     HOST_LIST: 'https://raw.githubusercontent.com/mozilla/http-observatory-dashboard/master/httpobsdashboard/conf/sites.json'

--- a/serverless.yml
+++ b/serverless.yml
@@ -76,6 +76,7 @@ functions:
           path: ondemand/sshobservatory
           method: POST
           cors: true
+          private: ${self:custom.cfg.private}
   onDemandTlsObservatoryScan:
     handler: handler.queue_tlsobservatory
     events:

--- a/tests/test_ssh_observatory_scanner.py
+++ b/tests/test_ssh_observatory_scanner.py
@@ -20,7 +20,7 @@ class TestSSHObservatoryScanner():
 
     def test_setting_api_url(self):
         # Stub env var for testing
-        os.environ["SSHOBS_API_URL"] = "https://sshscan.rubidus.com"
+        os.environ["SSHOBS_API_URL"] = "https://sshscan.rubidus.com/api/v1"
 
         scanner = SSHObservatoryScanner()
         assert scanner.poll_interval == 1
@@ -31,7 +31,7 @@ class TestSSHObservatoryScanner():
 
     def test_scan(self):
         # Stub env var for testing
-        os.environ["SSHOBS_API_URL"] = "https://sshscan.rubidus.com"
+        os.environ["SSHOBS_API_URL"] = "https://sshscan.rubidus.com/api/v1"
         host_name = "ssh.mozilla.com"
         scanner = SSHObservatoryScanner()
         scan_result = scanner.scan(host_name)


### PR DESCRIPTION
With our currently separated handler pattern (having many handlers instead of one and referring to them separately in "serverless.yml") does not work. While everything gets packaged correctly and uploaded, when invoked, a REST API endpoint returns "Internal server error" and logs reveal:

> "Handler 'queue' missing on module 'lib/httpobsscan_handler': module 'lib/httpobsscan_handler' has no attribute 'queue'"

This means the python runtime in Lambda is having trouble finding our user-defined modules.
There are some options to address this as far as I've read:

- Keep the single handler file in the project root, keep using it as the primary handler in "serverless.yml", and import other classes as modules in this (simplest).
- Modify the PYTHONPATH env variable in "serverless.yml" to include the directory that includes user-defined modules (also simple, but hacky)
 - Re-work the entire project folder structure in a way that each function has its own directory, like in here: https://dev.to/egrajeda/my-python-serverless-setup-ca1 (likely a big change)

**_This PR implements the 1st option above._**. It was also deployed and tested in AWS lambda using serverless and it works as intended.