### PR TITLE
Modify the examples and documentation to reflect authentication requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ _**Note:** UDP port scans are not supported as Lamdba functions can not run as r
         # Y for Tenable.io support, N or blank if not
         TENABLE_IO := Y / N 
         
-        # If you would like to create a dedicated KMS for vautomator
-        # Blank if you would like to use default AWS SSM key for
-        # encrypted storage
+        # If you would like to create a dedicated KMS for vautomator,
+        # specify a policy file here (an example policy file is
+        # provided in the repository). Otherwise leave blank if
+        # you would like to use default AWS SSM key for encrypted storage
         KMS_POLICY_FILE := <YOUR-KMS-POLICY-JSON-FILE>
         
         # Blank if a policy file is specified, 
@@ -66,7 +67,9 @@ _**Note:** UDP port scans are not supported as Lamdba functions can not run as r
 
 ## Examples
 
-- Once deployed properly, you can kick of an ondemand scan on a host, using: `API_GW_URL=<YOUR-REST-ENDPOINT> python3 examples/ondemand_tasker.py`
+- Once deployed properly, you can kick of an ondemand scan on a host, using: `API_PROFILE=<YOUR-AWS-PROFILE/ROLE> python3 examples/ondemand_tasker.py`. Alternatively, you can hard-code your AWS profile in a variable in the code for examples.
+  
+  Note: You must provide an AWS profile/role if you'd like to use them as clients. This is required in order to programmatically fetch the API gateway URL details for your vautomator-serverless instance, as well as the API gateway key which currently protects the REST APIs.
 
 ```
 Provide the FQDN (Fully Qualified Domain Name) you want to scan: infosec.mozilla.org
@@ -89,7 +92,7 @@ INFO:root:Triggered a web search of: infosec.mozilla.org
 To confirm all scans were performed and results were stored in S3 bucket:
 
 ```
-$ aws --profile <YOUR-PROFILE> s3 ls s3://<YOUR-S3-BUCKET> | sort -r
+$ aws --profile <YOUR-PROFILE> s3 ls s3://<YOUR-S3-BUCKET> | sort -r | head -n 10
 2019-04-10 00:03:17      10487 infosec.mozilla.org_httpobservatory.json
 2019-04-10 00:03:22      77028 infosec.mozilla.org_tlsobservatory.json
 2019-04-10 00:03:37       5709 infosec.mozilla.org_tcpscan.json

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is under development with more features being added as different branches. 
 - Addition of a target to the scan queue for TLS Observatory scan by an API endpoint (`/ondemand/tlsobservatory`)
 - Addition of a target to the scan queue for SSH Observatory scan by an API endpoint (`/ondemand/sshobservatory`).
 - Addition of a target to the scan queue for a directory enumeration scan (currently with `dirb`) by an API endpoint (`/ondemand/direnum`)
+- Addition of a target to the scan quque for a Google web search by an API endpoint (`/ondemand/websearch`)
 - _[OPTIONAL]_ Addition of a target to the scan queue for a Tenable.io scan by an API endpoint (`/ondemand/tenablescan`).
 - Performing requested scan type (port, HTTP Observatory, TLS Observatory or SSH Observatory) on hosts in the queue
 - Scheduled port scans from a hard-coded list of hosts (disabled by default)
@@ -69,18 +70,20 @@ _**Note:** UDP port scans are not supported as Lamdba functions can not run as r
 
 ```
 Provide the FQDN (Fully Qualified Domain Name) you want to scan: infosec.mozilla.org
-INFO:root:Sending POST to <YOUR-REST-ENDPOINT>
+INFO:root:Sending POST to <YOUR-REST-ENDPOINT>/ondemand/portscan
 INFO:root:Triggered a port scan of: infosec.mozilla.org
-INFO:root:Sending POST to <YOUR-REST-ENDPOINT>
+INFO:root:Sending POST to <YOUR-REST-ENDPOINT>/ondemand/httpobservatory
 INFO:root:Triggered a httpobservatory scan of: infosec.mozilla.org
-INFO:root:Sending POST to <YOUR-REST-ENDPOINT>
+INFO:root:Sending POST to <YOUR-REST-ENDPOINT>/ondemand/tlsobservatory
 INFO:root:Triggered a tlsobservatory scan of: infosec.mozilla.org
-INFO:root:Sending POST to <YOUR-REST-ENDPOINT>
+INFO:root:Sending POST to <YOUR-REST-ENDPOINT>/ondemand/sshobservatory
 INFO:root:Triggered an sshobservatory scan of: infosec.mozilla.org
-INFO:root:Sending POST to <YOUR-REST-ENDPOINT>
+INFO:root:Sending POST to <YOUR-REST-ENDPOINT>/ondemand/tenablescan
 INFO:root:Triggered a tenable scan of: infosec.mozilla.org
-INFO:root:Sending POST to <YOUR-REST-ENDPOINT>
+INFO:root:Sending POST to <YOUR-REST-ENDPOINT>/ondemand/direnum
 INFO:root:Triggered a direnum of: infosec.mozilla.org
+INFO:root:Sending POST to <YOUR-REST-ENDPOINT>/ondemand/websearch
+INFO:root:Triggered a web search of: infosec.mozilla.org
 ```
 
 To confirm all scans were performed and results were stored in S3 bucket:

--- a/examples/ondemand_tasker.py
+++ b/examples/ondemand_tasker.py
@@ -30,14 +30,16 @@ tlsobs_scan_url = API_GW_URL + "/dev/ondemand/tlsobservatory"
 sshobs_scan_url = API_GW_URL + "/dev/ondemand/sshobservatory"
 tenableio_scan_url = API_GW_URL + "/dev/ondemand/tenablescan"
 direnum_scan_url = API_GW_URL + "/dev/ondemand/direnum"
+websearch_url = API_GW_URL + "/dev/ondemand/websearch"
 
 scan_types = {
-    "port": portscan_url,
-    "httpobservatory": httpobs_scan_url,
-    "tlsobservatory": tlsobs_scan_url,
-    "sshobservatory": sshobs_scan_url,
-    "tenable": tenableio_scan_url,
-    "direnum": direnum_scan_url
+    'port': portscan_url,
+    'httpobservatory': httpobs_scan_url,
+    'tlsobservatory': tlsobs_scan_url,
+    'sshobservatory': sshobs_scan_url,
+    'websearch': websearch_url,
+    'tenable': tenableio_scan_url,
+    'direnum': direnum_scan_url
 }
 
 session = requests.Session()

--- a/examples/ondemand_tasker.py
+++ b/examples/ondemand_tasker.py
@@ -4,6 +4,7 @@ import json
 import time
 import os
 import sys
+import boto3
 sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 from lib.target import Target
 
@@ -12,25 +13,43 @@ from lib.target import Target
 # the interface an engineer could use to kick off a VA.
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
-try:
-    API_GW_URL = os.environ['API_GW_URL']
-except KeyError:
-    API_GW_URL = "https://y2ippncfd1.execute-api.us-west-2.amazonaws.com"
+# Can specify the profile/role in the code...
+AWS_PROFILE = ""
+
+if not AWS_PROFILE:
+    try:
+        # ...or read from an environment variable
+        AWS_PROFILE = os.environ['AWS_PROFILE']
+    except KeyError:
+        logging.error("AWS profile not found. Either specify it as an environment variable"
+                      " (AWS_PROFILE) or change the AWS_PROFILE variable in the code.")
+        sys.exit(-1)
+
+# Establish a session with that profile
+session = boto3.Session(profile_name=AWS_PROFILE)
+# Programmatically obtain the API GW URL, and the REST API key
+apigw_client = session.client('apigateway')
+aws_response = apigw_client.get_api_keys(
+    nameQuery='vautomator-serverless',
+    includeValues=True)['items'][0]
+rest_api_id, stage_name = "".join(aws_response['stageKeys']).split('/')
+gwapi_key = aws_response['value']
+API_GW_URL = "https://{}.execute-api.{}.amazonaws.com/".format(rest_api_id, session.region_name)
 
 fqdn = input("Provide the FQDN (Fully Qualified Domain Name) you want to scan: ")
 try:
     target = Target(fqdn)
 except AssertionError:
     logging.error("Target validation failed: target must be an FQDN or IPv4 only.")
-    sys.exit(-1)
+    sys.exit(-2)
 
-portscan_url = API_GW_URL + "/dev/ondemand/portscan"
-httpobs_scan_url = API_GW_URL + "/dev/ondemand/httpobservatory"
-tlsobs_scan_url = API_GW_URL + "/dev/ondemand/tlsobservatory"
-sshobs_scan_url = API_GW_URL + "/dev/ondemand/sshobservatory"
-tenableio_scan_url = API_GW_URL + "/dev/ondemand/tenablescan"
-direnum_scan_url = API_GW_URL + "/dev/ondemand/direnum"
-websearch_url = API_GW_URL + "/dev/ondemand/websearch"
+portscan_url = API_GW_URL + "{}/ondemand/portscan".format(stage_name)
+httpobs_scan_url = API_GW_URL + "{}/ondemand/httpobservatory".format(stage_name)
+tlsobs_scan_url = API_GW_URL + "{}/ondemand/tlsobservatory".format(stage_name)
+sshobs_scan_url = API_GW_URL + "{}/ondemand/sshobservatory".format(stage_name)
+tenableio_scan_url = API_GW_URL + "{}/ondemand/tenablescan".format(stage_name)
+direnum_scan_url = API_GW_URL + "{}/ondemand/direnum".format(stage_name)
+websearch_url = API_GW_URL + "{}/ondemand/websearch".format(stage_name)
 
 scan_types = {
     'port': portscan_url,
@@ -43,6 +62,7 @@ scan_types = {
 }
 
 session = requests.Session()
+session.headers.update({'X-Api-Key': gwapi_key})
 for scan, scan_url in scan_types.items():
     logging.info("Sending POST to {}".format(scan_url))
     response = session.post(scan_url, data="{\"target\":\"" + target.name + "\"}")

--- a/examples/realtime_ctlog_tasker.py
+++ b/examples/realtime_ctlog_tasker.py
@@ -25,14 +25,16 @@ tlsobs_scan_url = API_GW_URL + "/dev/ondemand/tlsobservatory"
 sshobs_scan_url = API_GW_URL + "/dev/ondemand/sshobservatory"
 tenableio_scan_url = API_GW_URL + "/dev/ondemand/tenablescan"
 direnum_scan_url = API_GW_URL + "/dev/ondemand/direnum"
+websearch_url = API_GW_URL + "/dev/ondemand/websearch"
 
 scan_types = {
-    "port": portscan_url,
-    "httpobservatory": httpobs_scan_url,
-    "tlsobservatory": tlsobs_scan_url,
-    "sshobservatory": sshobs_scan_url,
-    "tenable": tenableio_scan_url,
-    "direnum": direnum_scan_url
+    'port': portscan_url,
+    'httpobservatory': httpobs_scan_url,
+    'tlsobservatory': tlsobs_scan_url,
+    'sshobservatory': sshobs_scan_url,
+    'websearch': websearch_url,
+    'tenable': tenableio_scan_url,
+    'direnum': direnum_scan_url
 }
 
 


### PR DESCRIPTION
Small enhancements and inclusions to the examples (clients) and to the documentation (readme).

Main change is to update the examples to programmatically fetch the gateway API key required to invoke the REST API endpoints, given an AWS profile.

_Note, this authentication mechanism is temporary, until we implement something more robust._