### PR TITLE
Set 30 day retention on CloudWatch logs

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -413,6 +413,7 @@ plugins:
   - serverless-step-functions
   - serverless-prune-plugin
   - serverless-domain-manager
+  - serverless-plugin-log-retention
 
 resources:
   Resources:
@@ -488,3 +489,4 @@ custom:
   apigwBinary:
     types:
       - 'application/gzip'
+  logRetentionInDays: 30


### PR DESCRIPTION
I've applies this manually to the deployed stack in infosec-dev by manually changing all the LogGroup retention settings.